### PR TITLE
大佬，发现您的项目引入了com.itextpdf:itextpdf@5.5.6组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.xjc</groupId>
@@ -25,7 +24,7 @@
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <hutool.version>5.6.5</hutool.version>
         <pdfbox.version>2.0.8</pdfbox.version>
-        <itextpdf.version>5.5.6</itextpdf.version>
+        <itextpdf.version>5.5.12</itextpdf.version>
         <itext-asian.version>5.2.0</itext-asian.version>
         <pdfbox.version>2.0.8</pdfbox.version>
         <thumbnailator.version>0.4.14</thumbnailator.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：iText XML解析器代码问题漏洞
缺陷组件：com.itextpdf:itextpdf@5.5.6
漏洞编号：CVE-2017-9096
漏洞描述：iText是一套能够生成PDF报表的软件开发工具包。XML parsers是其中的一个XML解析器。
iText 5.5.12之前的版本和7.0.3之前的7.x版本中的XML解析器存在安全漏洞，该漏洞源于程序不能打开外部的实体。远程攻击者可借助特制的PDF利用该漏洞执行XML外部实体注入攻击。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2017-36203
影响范围：(∞, 5.5.12)
最小修复版本：5.5.12
缺陷组件引入路径：com.xjc:tool@0.0.1-SNAPSHOT->com.itextpdf:itextpdf@5.5.6
```
另外我运行这个项目时，IDE的安全插件提示还有34个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pb6971